### PR TITLE
Cloudflareの認証ヘッダーを追加

### DIFF
--- a/apps/mobile/src/lib/generateTarotMessageCloudflare.ts
+++ b/apps/mobile/src/lib/generateTarotMessageCloudflare.ts
@@ -12,9 +12,10 @@ export const generateTarotMessage = async (name: string, meaning: string) => {
 タロットカード「${name}」に基づいて正位置と逆位置の文言を生成してください。
 キーワード: ${meaning}
 `;
-  const api_token = process.env.EXPO_PUBLIC_GEMINI_API_KEY || '';
+  const api_key = process.env.EXPO_PUBLIC_GEMINI_API_KEY || '';
   const account_id = process.env.EXPO_PUBLIC_CLOUDFLARE_ACCOUNT_ID || '';
   const gateway_name = process.env.EXPO_PUBLIC_CLOUDFLARE_GATEWAY_NAME || '';
+  const token = process.env.EXPO_PUBLIC_CLOUDFLARE_TOKEN || '';
 
   const geminiApiEndpoint =
     // "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent";
@@ -40,7 +41,7 @@ export const generateTarotMessage = async (name: string, meaning: string) => {
   };
 
   try {
-    // const genAI = new GoogleGenerativeAI(api_token);
+    // const genAI = new GoogleGenerativeAI(api_key);
     // const model = await genAI.getGenerativeModel(
     //   {
     //     model: "gemini-2.0-flash-lite",
@@ -78,7 +79,8 @@ export const generateTarotMessage = async (name: string, meaning: string) => {
       {
         headers: {
           'Content-Type': 'application/json',
-          'x-goog-api-key': api_token,
+          'x-goog-api-key': api_key,
+          'cf-aig-authorization': `Bearer ${token}`,
         },
       }
     );

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,6 +14,7 @@ const nextConfig: NextConfig = {
   env: {
     CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID!,
     CLOUDFLARE_GATEWAY_NAME: process.env.CLOUDFLARE_GATEWAY_NAME!,
+    CLOUDFLARE_API_TOKEN: process.env.CLOUDFLARE_API_TOKEN!,
     GEMINI_API_KEY: process.env.GEMINI_API_KEY!,
   },
 };

--- a/apps/web/src/app/api/tarot/api.ts
+++ b/apps/web/src/app/api/tarot/api.ts
@@ -20,6 +20,7 @@ export const tarotApi = new Hono().post(
 
       const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
       const gatewayId = process.env.CLOUDFLARE_GATEWAY_NAME;
+      const apiToken = process.env.CLOUDFLARE_TOKEN;
 
       if (!accountId || !gatewayId) {
         console.error("Missing Cloudflare credentials");
@@ -55,6 +56,7 @@ export const tarotApi = new Hono().post(
         headers: {
           "Content-Type": "application/json",
           "x-goog-api-key": process.env.GEMINI_API_KEY!,
+          "cf-aig-authorization": `Bearer ${apiToken}`,
         },
         body: JSON.stringify({
           contents: [

--- a/apps/web/src/app/api/tarot/api.ts
+++ b/apps/web/src/app/api/tarot/api.ts
@@ -20,7 +20,7 @@ export const tarotApi = new Hono().post(
 
       const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
       const gatewayId = process.env.CLOUDFLARE_GATEWAY_NAME;
-      const apiToken = process.env.CLOUDFLARE_TOKEN;
+      const apiToken = process.env.CLOUDFLARE_API_TOKEN;
 
       if (!accountId || !gatewayId) {
         console.error("Missing Cloudflare credentials");

--- a/apps/web/src/lib/generateTarotMessageGemini.ts
+++ b/apps/web/src/lib/generateTarotMessageGemini.ts
@@ -5,6 +5,9 @@ import { zodResponseFormat } from "openai/helpers/zod";
 const client = new OpenAI({
   apiKey: process.env.GEMINI_API_KEY,
   baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+  defaultHeaders: {
+    "cf-aig-authorization": `Bearer ${process.env.CLOUDFLARE_TOKEN}`,
+  },
 });
 
 export const generateTarotMessageGemini = async (

--- a/apps/web/src/lib/generateTarotMessageGemini.ts
+++ b/apps/web/src/lib/generateTarotMessageGemini.ts
@@ -6,7 +6,7 @@ const client = new OpenAI({
   apiKey: process.env.GEMINI_API_KEY,
   baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
   defaultHeaders: {
-    "cf-aig-authorization": `Bearer ${process.env.CLOUDFLARE_TOKEN}`,
+    "cf-aig-authorization": `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
   },
 });
 

--- a/packages/tarot-logic/src/generateTarotMessageWeb.ts
+++ b/packages/tarot-logic/src/generateTarotMessageWeb.ts
@@ -16,6 +16,7 @@ type TarotResponse = z.infer<typeof TarotResponseSchema>;
 const apiKey = process.env.OPENAI_API_KEY;
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 const gatewayId = process.env.CLOUDFLARE_GATEWAY_NAME;
+const apiToken = process.env.CLOUDFLARE_API_TOKEN;
 const baseURL =
   accountId && gatewayId
     ? `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/openai`
@@ -24,6 +25,9 @@ const baseURL =
 const client = new OpenAI({
   apiKey,
   baseURL, // baseURL will be undefined if env vars are missing, OpenAI client might handle this or throw error
+  defaultHeaders: {
+    "cf-aig-authorization": `Bearer ${apiToken}`,
+  },
 });
 
 export const generateTarotMessageWeb = async (


### PR DESCRIPTION
タロットメッセージ生成機能において、APIキーとトークンの環境変数名を統一し、Cloudflareの認証ヘッダーを追加。
これにより、API呼び出しの整合性が向上し、セキュリティが強化された。